### PR TITLE
Configure npm publishing for all workspace packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,70 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm -r test -- --exclude='**/*.smoke.test.ts'
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish all packages with provenance
+        run: pnpm -r publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
   "bugs": {
     "url": "https://github.com/oldeucryptoboi/KarnEvil9/issues"
   },
-  "bin": {
-    "karnevil9": "packages/cli/dist/index.js"
-  },
+  "private": true,
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,11 @@
     "@types/express": "^5.0.0",
     "@types/ws": "^8.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/browser-relay/package.json
+++ b/packages/browser-relay/package.json
@@ -25,6 +25,11 @@
     "@types/express": "^5.0.0",
     "@types/ws": "^8.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,11 @@
   "devDependencies": {
     "@types/ws": "^8.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/journal/package.json
+++ b/packages/journal/package.json
@@ -15,6 +15,11 @@
     "@karnevil9/schemas": "workspace:*",
     "uuid": "^11.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -23,6 +23,11 @@
   "devDependencies": {
     "@karnevil9/planner": "workspace:*"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -15,6 +15,11 @@
     "@karnevil9/schemas": "workspace:*",
     "uuid": "^11.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -16,6 +16,11 @@
     "@karnevil9/journal": "workspace:*",
     "prom-client": "^15.1.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -17,6 +17,11 @@
     "cron-parser": "^4.9.0",
     "uuid": "^11.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/planner/package.json
+++ b/packages/planner/package.json
@@ -15,6 +15,11 @@
     "@karnevil9/schemas": "workspace:*",
     "uuid": "^11.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -22,6 +22,11 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -20,6 +20,11 @@
   "devDependencies": {
     "@types/uuid": "^10.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -18,6 +18,11 @@
   "devDependencies": {
     "uuid": "^11.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/swarm/package.json
+++ b/packages/swarm/package.json
@@ -21,6 +21,11 @@
     "@types/multicast-dns": "^7.2.4",
     "@types/uuid": "^10.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -21,6 +21,11 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -21,6 +21,11 @@
     "@types/js-yaml": "^4.0.9",
     "@types/uuid": "^10.0.0"
   },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Mark root `package.json` as `private: true` to prevent accidental publish of the monorepo root
- Add `"files": ["dist"]` and `"publishConfig": { "access": "public", "provenance": true }` to all 15 workspace packages
- Fix publish workflow to use `pnpm -r publish` (all packages) instead of `npm publish` (root only)
- Add `NODE_AUTH_TOKEN` env var for CI npm authentication

## Test plan
- [x] All 2,574 tests pass (verified by pre-push hook)
- [ ] Create `@karnevil9` org on npmjs.com
- [ ] Add `NPM_TOKEN` to GitHub repo secrets
- [ ] Tag `v0.1.0` and verify workflow publishes all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)