### PR TITLE
Fix blog and demos pages returning 404

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,9 +9,7 @@ plugins:
   - jekyll-sitemap
 include:
   - images
-exclude:
-  - "demos/"
-  - "blog/"
+exclude: []
 defaults:
   - scope:
       path: ""

--- a/docs/blog/dev-to-zork-post.md
+++ b/docs/blog/dev-to-zork-post.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "We Tried to Hide Zork From an LLM. It Identified the Game Anyway."
+---
+
 # We Tried to Hide Zork From an LLM. It Identified the Game Anyway.
 
 ## How we built a governed AI agent to play text adventures — and what broke first

--- a/docs/blog/substack-self-play-to-delegation.md
+++ b/docs/blog/substack-self-play-to-delegation.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "From Self-Play to Safety: The Six-Year Arc Between Two DeepMind Papers"
+---
+
 # From Self-Play to Safety: The Six-Year Arc Between Two DeepMind Papers
 
 ### How "Imitating Interactive Intelligence" (2020) planted the seed that "Intelligent AI Delegation" (2026) grew into a governance framework — and what we learned building the bridge

--- a/docs/blog/substack-zork-post.md
+++ b/docs/blog/substack-zork-post.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: "The Safety System That Wouldn't Let My AI Win at Zork"
+---
+
 # The Safety System That Wouldn't Let My AI Win at Zork
 
 ### What happens when you wire Google DeepMind's delegation framework into a text adventure — and it decides "kill troll" is too dangerous

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,12 @@ pnpm install && pnpm build
 karnevil9 run "list all TypeScript files" --planner claude --mode real
 ```
 
+## Blog
+
+- [From Self-Play to Safety: The Six-Year Arc Between Two DeepMind Papers](blog/substack-self-play-to-delegation)
+- [The Safety System That Wouldn't Let My AI Win at Zork](blog/substack-zork-post)
+- [We Tried to Hide Zork From an LLM. It Identified the Game Anyway.](blog/dev-to-zork-post)
+
 ## Documentation
 
 - [Architecture Reference](architecture)


### PR DESCRIPTION
## Summary
- Removed `blog/` and `demos/` from the Jekyll `exclude` list in `_config.yml` — these directories were being skipped during the site build, causing all blog posts and demo pages to 404
- Added Jekyll front matter (`layout: default`, `title`) to all three blog posts so they render properly
- Added a Blog section to `index.md` linking to all three posts

## Test plan
- [ ] Merge to master and confirm the Pages workflow runs successfully
- [ ] Verify blog posts are accessible at `/KarnEvil9/blog/substack-self-play-to-delegation`, `/KarnEvil9/blog/substack-zork-post`, `/KarnEvil9/blog/dev-to-zork-post`
- [ ] Verify demo pages are accessible at `/KarnEvil9/demos/claude-code-hello-world.html` and `/KarnEvil9/demos/memory-vs-rlm.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)