### PR TITLE
Update blog post title to Tarkus

### DIFF
--- a/docs/blog/substack-self-play-to-delegation.md
+++ b/docs/blog/substack-self-play-to-delegation.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "From Self-Play to Safety: The Six-Year Arc Between Two DeepMind Papers"
+title: "Tarkus: a Native macOS Client for My AI Agent"
 ---
 
 # From Self-Play to Safety: The Six-Year Arc Between Two DeepMind Papers

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ karnevil9 run "list all TypeScript files" --planner claude --mode real
 
 ## Blog
 
-- [From Self-Play to Safety: The Six-Year Arc Between Two DeepMind Papers](blog/substack-self-play-to-delegation)
+- [Tarkus: a Native macOS Client for My AI Agent](blog/substack-self-play-to-delegation)
 - [The Safety System That Wouldn't Let My AI Win at Zork](blog/substack-zork-post)
 - [We Tried to Hide Zork From an LLM. It Identified the Game Anyway.](blog/dev-to-zork-post)
 


### PR DESCRIPTION
## Summary
- Renamed blog post title from "From Self-Play to Safety..." to "Tarkus: a Native macOS Client for My AI Agent"
- Updated the corresponding link on the index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)